### PR TITLE
Replace 3.9-dev with 3.9 in CI to use python 3.9 final

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache: pip
 matrix:
   fast_finish: true
   include:
-    - python: 3.9-dev
+    - python: 3.9
     - python: 3.8
     - python: 3.7
     - python: 3.6


### PR DESCRIPTION
because this repository was mentioned here:
https://github.com/hugovk/pypistats/issues/181